### PR TITLE
Use LLVM IR instead of LLVM bitcode

### DIFF
--- a/src/interpreter/ExecutableGenerator.cpp
+++ b/src/interpreter/ExecutableGenerator.cpp
@@ -40,7 +40,7 @@ std::string EmitBitcode(llvm::Module* module, bool optimize) {
 }
 
 std::string EmitExecutable(llvm::Module* module, bool optimize) {
-    auto bitcode_path = EmitBitcode(module, optimize);
+    auto llvmir_path = EmitLLVMIR(module, optimize);
 
 #if _WIN32
 
@@ -63,7 +63,7 @@ std::string EmitExecutable(llvm::Module* module, bool optimize) {
 #endif
 
     compile_command << " ";
-    compile_command << bitcode_path;
+    compile_command << llvmir_path;
 
     KAPRINO_LOG("Execute external tool: " << compile_command.str());
 

--- a/src/interpreter/ExecutableGenerator.h
+++ b/src/interpreter/ExecutableGenerator.h
@@ -2,7 +2,7 @@
 
 #include "llvm/IR/Module.h"
 
-void EmitLLVMIR(llvm::Module* module, bool optimize);
+std::string EmitLLVMIR(llvm::Module* module, bool optimize);
 
 std::string EmitBitcode(llvm::Module* module, bool optimize);
 


### PR DESCRIPTION
I found that building LLVM bitcode with clang requires the LLVM versions between bitcode and clang to be the same, while LLVM IR doesn't.
It's so useful right?